### PR TITLE
Increase memory limit

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -8,7 +8,7 @@ module CC
 
       attr_reader :name
 
-      DEFAULT_MEMORY_LIMIT = 1_024_000_000
+      DEFAULT_MEMORY_LIMIT = 1_024_000_000.freeze
 
       def initialize(name, metadata, code_path, config, label)
         @name = name

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -8,7 +8,7 @@ module CC
 
       attr_reader :name
 
-      DEFAULT_MEMORY_LIMIT = 512_000_000.freeze
+      DEFAULT_MEMORY_LIMIT = 1_024_000_000
 
       def initialize(name, metadata, code_path, config, label)
         @name = name


### PR DESCRIPTION
`Reek` engine was `failed` with `status 137` which is related to `codeclimate` engine `memory limit`. So, we increase this limit, in order to fix this issue.