### PR TITLE
Add support to Extensions normalizer

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -22,6 +22,7 @@ module CC
     autoload :LocationDescription, "cc/analyzer/location_description"
     autoload :LoggingContainerListener, "cc/analyzer/logging_container_listener"
     autoload :MountedPath, "cc/analyzer/mounted_path"
+    autoload :Normalizers, "cc/analyzer/normalizers"
     autoload :RaisingContainerListener, "cc/analyzer/raising_container_listener"
     autoload :SourceBuffer, "cc/analyzer/source_buffer"
     autoload :SourceExtractor, "cc/analyzer/source_extractor"

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -117,14 +117,14 @@ module CC
       end
 
       # Removes unsuported extensions from each
-      # engine config file according with suplied channel
+      # engine config file according with supplied channel
       def normalize_engine_extensions!
         return unless @metadata["channels"]
 
         channel_metadata = @metadata["channels"][channel_name]
         extensions = channel_metadata["extensions"] || []
 
-        Normalizers::Extension.new(name, extensions, @code_path).call
+        ::CC::Analyzer::Normalizers::Extension.new(name, extensions, @code_path).call
       end
     end
   end

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -12,7 +12,19 @@ module CC
         # handling.
         def fetch(name, channel)
           metadata = self[name]
-          metadata.merge("image" => metadata["channels"][channel.to_s])
+          metadata.merge("image" => image_data(metadata["channels"], channel))
+        end
+
+        private
+
+        def image_data(channels, channel)
+          channel = channels[channel.to_s]
+
+          if channel.is_a?(Hash) && channel.key?("image")
+            return channel["image"]
+          end
+
+          channel
         end
       end
 

--- a/lib/cc/analyzer/normalizers.rb
+++ b/lib/cc/analyzer/normalizers.rb
@@ -1,0 +1,8 @@
+module CC
+  module Analyzer
+    module Normalizers
+      autoload :Extension, "cc/analyzer/normalizers/extension"
+      autoload :Extensions, "cc/analyzer/normalizers/extensions"
+    end
+  end
+end

--- a/lib/cc/analyzer/normalizers/extension.rb
+++ b/lib/cc/analyzer/normalizers/extension.rb
@@ -4,7 +4,7 @@ module CC
       class Extension
         attr_reader :name, :extensions, :code_path
 
-        def initialize(name, available_extensions = [], code_path)
+        def initialize(name, available_extensions = [], code_path = "")
           @name = name
           @extensions = available_extensions
           @code_path = code_path

--- a/lib/cc/analyzer/normalizers/extension.rb
+++ b/lib/cc/analyzer/normalizers/extension.rb
@@ -25,7 +25,7 @@ module CC
         end
 
         def engine_normalizer_const
-          "#{namespace}::Extensions::#{name.capitalize}Extension"
+          "#{namespace}::Extensions::#{name.underscore.classify}Extension"
         end
       end
     end

--- a/lib/cc/analyzer/normalizers/extension.rb
+++ b/lib/cc/analyzer/normalizers/extension.rb
@@ -2,7 +2,6 @@ module CC
   module Analyzer
     module Normalizers
       class Extension
-
         attr_reader :name, :extensions, :code_path
 
         def initialize(name, available_extensions = [], code_path)

--- a/lib/cc/analyzer/normalizers/extension.rb
+++ b/lib/cc/analyzer/normalizers/extension.rb
@@ -1,0 +1,34 @@
+module CC
+  module Analyzer
+    module Normalizers
+      class Extension
+
+        attr_reader :name, :extensions, :code_path
+
+        def initialize(name, available_extensions = [], code_path)
+          @name = name
+          @extensions = available_extensions
+          @code_path = code_path
+        end
+
+        def call
+          if Kernel.const_defined?(engine_normalizer_const)
+            engine_normalizer_klass = Kernel.const_get(engine_normalizer_const)
+
+            engine_normalizer_klass.new(extensions, code_path).call
+          end
+        end
+
+        private
+
+        def namespace
+          self.class.to_s.deconstantize
+        end
+
+        def engine_normalizer_const
+          "#{namespace}::Extensions::#{name.capitalize}Extension"
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/normalizers/extensions.rb
+++ b/lib/cc/analyzer/normalizers/extensions.rb
@@ -1,0 +1,9 @@
+module CC
+  module Analyzer
+    module Normalizers
+      module Extensions
+        autoload :RubocopExtension, "cc/analyzer/normalizers/extensions/rubocop_extension"
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
+++ b/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
@@ -17,7 +17,7 @@ module CC
           def call
             extensions = config_file["require"]
 
-            return if extensions.empty?
+            return if extensions.blank?
 
             supported_extensions = available_extensions & extensions
 

--- a/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
+++ b/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
@@ -5,7 +5,7 @@ module CC
     module Normalizers
       module Extensions
         class RubocopExtension
-          CONFIG_FILE_PATH = '.rubocop.yml'.freeze
+          CONFIG_FILE_PATH = ".rubocop.yml".freeze
 
           attr_reader :available_extensions, :code_path
 

--- a/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
+++ b/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module CC
+  module Analyzer
+    module Normalizers
+      module Extensions
+        class RubocopExtension
+          CONFIG_FILE_PATH = '.rubocop.yml'
+
+          attr_reader :available_extensions, :code_path
+
+          def initialize(available_extensions, code_path)
+            @available_extensions = available_extensions
+            @code_path = code_path
+          end
+
+          def call
+            begin
+              extensions = config_file["require"]
+
+              return if extensions.empty?
+
+              supported_extensions = available_extensions & extensions
+
+              config_file["require"] = supported_extensions
+
+              normalize!
+            rescue Errno::ENOENT
+            end
+          end
+
+          private
+
+          def config_file
+            @config_file ||= YAML.load_file(config_file_path)
+          end
+
+          def normalize!
+            File.open(config_file_path, "w") do |file|
+              YAML.dump(config_file, file)
+            end
+          end
+
+          def config_file_path
+            @config_file_path ||= "#{code_path}/#{CONFIG_FILE_PATH}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
+++ b/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
@@ -15,18 +15,16 @@ module CC
           end
 
           def call
-            begin
-              extensions = config_file["require"]
+            extensions = config_file["require"]
 
-              return if extensions.empty?
+            return if extensions.empty?
 
-              supported_extensions = available_extensions & extensions
+            supported_extensions = available_extensions & extensions
 
-              config_file["require"] = supported_extensions
+            config_file["require"] = supported_extensions
 
-              normalize!
-            rescue Errno::ENOENT
-            end
+            normalize!
+          rescue Errno::ENOENT
           end
 
           private

--- a/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
+++ b/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
@@ -5,7 +5,7 @@ module CC
     module Normalizers
       module Extensions
         class RubocopExtension
-          CONFIG_FILE_PATH = '.rubocop.yml'
+          CONFIG_FILE_PATH = '.rubocop.yml'.freeze
 
           attr_reader :available_extensions, :code_path
 

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -124,6 +124,62 @@ module CC::Analyzer
           expect(stdout.string).to include %{"severity":"info"}
         end
       end
+
+      it "when using engine without extension definition" do
+        container = double
+        allow(container).to receive(:on_output).and_yield("")
+        allow(container).to receive(:run).and_return(
+          Container::Result.new(0, false, 1, false, 10, ""),
+        )
+
+        expect(Container).to receive(:new) do |args|
+          expect(args[:image]).to eq "codeclimate/foo"
+          expect(args[:command]).to eq "bar"
+          expect(args[:name]).to match(/^cc-engines-foo/)
+        end.and_return(container)
+
+        metadata = {
+          "image" => "codeclimate/foo",
+          "command" => "bar",
+          "channels" => {
+            "stable" => "codeclimate/foo"
+          }
+        }
+
+        engine = Engine.new("foo", metadata, "/code", {}, "")
+        engine.run(StringIO.new, ContainerListener.new)
+      end
+
+      it "when using engine with extensions definition" do
+        container = double
+        allow(container).to receive(:on_output).and_yield("")
+        allow(container).to receive(:run).and_return(
+          Container::Result.new(0, false, 1, false, 10, ""),
+        )
+
+        expect(Container).to receive(:new) do |args|
+          expect(args[:image]).to eq "codeclimate/foo"
+          expect(args[:command]).to eq "bar"
+          expect(args[:name]).to match(/^cc-engines-foo/)
+        end.and_return(container)
+
+        metadata = {
+          "image" => "codeclimate/foo",
+          "command" => "bar",
+          "channels" => {
+            "stable" => {
+              "image" => "codeclimate/foo",
+              "extensions" => [
+                "rubocop/migrations",
+                "rubocop-rspec"
+              ]
+            }
+          }
+        }
+
+        engine = Engine.new("foo", metadata, "", {}, "")
+        engine.run(StringIO.new, ContainerListener.new)
+      end
     end
   end
 end

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -61,6 +61,27 @@ module CC::Analyzer
       end
     end
 
+    describe "with an extension specs for channel" do
+      it "selects the proper image" do
+        name = "an_engine"
+        registry = registry_with_engine(name)
+
+        registry[name]["channels"]["beta"] = {
+          "image" => "images/beta",
+          "extensions" => [
+            "an_engine/my_ext"
+          ]
+        }
+
+        config = config_with_engine(name)
+        config.engines[name].channel = "beta"
+
+        result = build_configs(registry, config).first
+
+        expect(result.registry_entry["image"]).to eq "images/beta"
+      end
+    end
+
     describe "with engine-specific config" do
       let(:config) do
         CC::Yaml.parse <<-EOYAML

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -44,11 +44,36 @@ module CC::Analyzer
       end
     end
 
+    describe "when registry follows extension spec format" do
+      it "builds and runs enabled engines from the registry with the formatter" do
+        config = config_with_engine("an_engine")
+        registry = registry_with_engine("an_engine", exts: ["an_engine/my_ext"])
+        formatter = null_formatter
+
+        expect_engine_run("an_engine", "/code", formatter)
+
+        EnginesRunner.new(registry, formatter, "/code", config).run
+      end
+    end
+
     def registry_with_engine(name)
       {
         name => {
           "channels" => {
             "stable" => "codeclimate/codeclimate-#{name}"
+          }
+        }
+      }
+    end
+
+    def registry_with_engine(name, exts: [])
+      {
+        name => {
+          "channels" => {
+            "stable" => {
+              "image" => "codeclimate/codeclimate-#{name}",
+              "extensions" => exts
+            }
           }
         }
       }

--- a/spec/cc/analyzer/normalizers/extension_spec.rb
+++ b/spec/cc/analyzer/normalizers/extension_spec.rb
@@ -9,6 +9,12 @@ module CC::Analyzer::Normalizers
         expect { extension.call }.to_not raise_error
       end
 
+      it "ignores custom engine name when there is no normalizer for it" do
+        extension = Extension.new("sass-lint", [], "/tmp/code")
+
+        expect { extension.call }.to_not raise_error
+      end
+
       it "calls normalizer class for engine" do
         extension = Extension.new("rubocop", [], "/tmp/code")
 

--- a/spec/cc/analyzer/normalizers/extension_spec.rb
+++ b/spec/cc/analyzer/normalizers/extension_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+module CC::Analyzer::Normalizers
+  describe Extension do
+    describe "#run" do
+      it "ignores engine when there is no normalizer for it" do
+        extension = Extension.new("reek", [], "/tmp/code")
+
+        expect { extension.call }.to_not raise_error
+      end
+
+      it "calls normalizer class for engine" do
+        extension = Extension.new("rubocop", [], "/tmp/code")
+
+        expect_any_instance_of(CC::Analyzer::Normalizers::Extensions::RubocopExtension).to receive(:call)
+        extension.call
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/normalizers/extensions/rubocop_extension_spec.rb
+++ b/spec/cc/analyzer/normalizers/extensions/rubocop_extension_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+module CC::Analyzer::Normalizers::Extensions
+  describe RubocopExtension do
+    include FileSystemHelpers
+
+    describe "#call" do
+      it "removes unsupported extensions from Rubocop config file" do
+        available_extensions = [
+          "rubocop-performance",
+          "rubocop/migrations",
+          "rubocop-rails"
+        ]
+
+        rubocop_config_content = <<-eos
+          require:
+            - rubocop-performance
+            - rubocop/migrations
+            - unsupported-ext
+
+          AllCops:
+            Exclude:
+              - 'bin/**/*'
+
+          RandomCheck:
+            Enabled: true
+        eos
+
+        path = "/tmp/code"
+        make_file("#{path}/.rubocop.yml", rubocop_config_content)
+
+        RubocopExtension.new(available_extensions, path).call
+
+        normalized_extensions = YAML.load_file("#{path}/.rubocop.yml")["require"]
+        expect(normalized_extensions).to_not include("unsupported-ext")
+        expect(normalized_extensions.size).to eq(2)
+      end
+
+      it "ignores process when there is no config file" do
+        expect { RubocopExtension.new(available_extensions, "/tmp/code").call }.to_not raise_error
+      end
+
+      private
+
+      def available_extensions
+        [
+          "rubocop-performance",
+          "rubocop/migrations",
+          "rubocop-rails"
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Currently, when the user tries to use a custom check (`extension`) for `rubocop` we fail the entire review for this engine. 

## Proposed solution

Suppress errors by removing unsupported Rubocop extension for the specified channel.

- [x] Support `channel` metadata spec
- [x] Check compatibility with available extensions
- [x] Remove unsupported extension from project `./.rubocop.yml` file


