### PR TITLE
Classify engine name to avoid invalid constant

### DIFF
--- a/lib/cc/analyzer/normalizers/extension.rb
+++ b/lib/cc/analyzer/normalizers/extension.rb
@@ -25,7 +25,7 @@ module CC
         end
 
         def engine_normalizer_const
-          "#{namespace}::Extensions::#{name.capitalize}Extension"
+          "#{namespace}::Extensions::#{name.underscore.classify}Extension"
         end
       end
     end

--- a/spec/cc/analyzer/normalizers/extension_spec.rb
+++ b/spec/cc/analyzer/normalizers/extension_spec.rb
@@ -9,6 +9,12 @@ module CC::Analyzer::Normalizers
         expect { extension.call }.to_not raise_error
       end
 
+      it "ignores custom engine name when there is no normalizer for it" do
+        extension = Extension.new("sass-lint", [], "/tmp/code")
+
+        expect { extension.call }.to_not raise_error
+      end
+
       it "calls normalizer class for engine" do
         extension = Extension.new("rubocop", [], "/tmp/code")
 


### PR DESCRIPTION
## Motivation

Some engines has a special characters on its name, just translating it gives us an invalid constant name.

## Solution

Transforms it in `underscore` then `classify` to receive a valid constant name for Ruby.