### PR TITLE
Fix Inline Extensions Error

### DIFF
--- a/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
+++ b/lib/cc/analyzer/normalizers/extensions/rubocop_extension.rb
@@ -19,7 +19,7 @@ module CC
 
             return if extensions.blank?
 
-            supported_extensions = available_extensions & extensions
+            supported_extensions = available_extensions & ([] << extensions).flatten
 
             config_file["require"] = supported_extensions
 

--- a/spec/cc/analyzer/normalizers/extensions/rubocop_extension_spec.rb
+++ b/spec/cc/analyzer/normalizers/extensions/rubocop_extension_spec.rb
@@ -36,6 +36,33 @@ module CC::Analyzer::Normalizers::Extensions
         expect(normalized_extensions.size).to eq(2)
       end
 
+      it "supports extensions inline syntax" do
+        available_extensions = [
+          "rubocop-performance",
+          "rubocop/migrations",
+          "rubocop-rails"
+        ]
+
+        rubocop_config_content = <<-eos
+          require: rubocop/migrations
+
+          AllCops:
+            Exclude:
+              - 'bin/**/*'
+
+          RandomCheck:
+            Enabled: true
+        eos
+
+        path = "/tmp/code"
+        make_file("#{path}/.rubocop.yml", rubocop_config_content)
+
+        RubocopExtension.new(available_extensions, path).call
+
+        normalized_extensions = YAML.load_file("#{path}/.rubocop.yml")["require"]
+        expect(normalized_extensions.size).to eq(1)
+      end
+
       it "ignores process when there is no config file" do
         expect { RubocopExtension.new(available_extensions, "/tmp/code").call }.to_not raise_error
       end


### PR DESCRIPTION
## Motivation

In our failed reviews page we discover some reviews that use inline extensions in Rubocop config file are failing. So, we take this to investigate in our Code Quality Sessions. The problem is that we always expect extensions array in Code Climate CLI, but in case of inline extensions, we got a string instead array.

## Proposed Solution

- [x] `append` and `flatten` to an empty array the extensions listing

## How to test

This `codeclimate` gem has an additional behavior that removes any Rubocop extensions that isn't included on it.

To use an extension, put this into your `.rubocop.yml`:

```yaml
require:
  - rubocop-other-extension
  - rubocop-rails
```

The syntax above is how it works currently. Otherwise, if you try to use only a single extension with this syntax, it will break:

```yaml
require: rubocop-rails
```

In order to reproduce this issue we recommend to perform a review using current `codeclimate` version. And after reproducing the issue for the single extension, try to change your `sourcelevel` Gemfile to this:

```ruby
gem 'codeclimate', git: 'git@github.com:sourcelevel/codeclimate.git', branch: 'ga-wt/fix-inline-extensions-error'
```

Run `bundle install`, restart `Sidekiq` then perform review again, it should work for both syntax.
